### PR TITLE
Add Jekyll configuration and homepage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+title: Math Notes
+description: A collection of math notes.
+theme: jekyll-theme-minimal

--- a/index.md
+++ b/index.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Home
+---
+
+<nav>
+  <a href="/">Home</a> |
+  <a href="/notes/">Notes</a> |
+  <a href="/index.json">Index JSON</a>
+</nav>
+
+# Welcome
+
+This site hosts mathematical notes.


### PR DESCRIPTION
## Summary
- configure Jekyll with `jekyll-theme-minimal`
- add a simple home page with default layout and navigation

## Testing
- `python scripts/build_index.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2d29495d0832a93833bc959c9866f